### PR TITLE
Fixed warning.

### DIFF
--- a/dist/react-xterm.js
+++ b/dist/react-xterm.js
@@ -29,7 +29,7 @@ class XTerm extends React.Component {
     componentDidMount() {
         const xtermInstance = this.getXTermInstance();
         this.xterm = new xtermInstance(this.props.options);
-        this.xterm.open(this.refs.container);
+        this.xterm.open(this.refs.container, true);
         this.xterm.on('focus', this.focusChanged.bind(this, true));
         this.xterm.on('blur', this.focusChanged.bind(this, false));
         if (this.props.onInput) {

--- a/src/react-xterm.tsx
+++ b/src/react-xterm.tsx
@@ -55,7 +55,7 @@ export default class XTerm extends React.Component<IXtermProps, IXtermState>{
 		// require('xterm/addons/fit/fit');
 		// require('xterm/addons/fullscreen/fullscreen');
 		this.xterm = new xtermInstance(this.props.options);
-		this.xterm.open(this.refs.container);
+		this.xterm.open(this.refs.container, true);
 		this.xterm.on('focus', this.focusChanged.bind(this, true));
 		this.xterm.on('blur', this.focusChanged.bind(this, false));
 		if (this.props.onInput) {


### PR DESCRIPTION
Warning: You did not pass the `focus` argument in `Terminal.prototype.open()`.
The `focus` argument now defaults to `true` but starting with xterm.js 3.0 it will default to `false`.
